### PR TITLE
CryptKeeper: pattern unlock displays incorrect pw when correct

### DIFF
--- a/src/com/android/settings/CryptKeeper.java
+++ b/src/com/android/settings/CryptKeeper.java
@@ -178,6 +178,7 @@ public class CryptKeeper extends Activity implements TextView.OnEditorActionList
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
+            mLockPatternView.removeCallbacks(mFakeUnlockAttemptRunnable);
             beginAttempt();
         }
 


### PR DESCRIPTION
fakeUnlockAttempt() gets called when the user inputs any pattern length
< 4 which queues up the 'incorrect error' message. The message needs to
be cleared before trying to actually check the password so it never goes
through in case the password was correct.

Change-Id: If78db332d3d696ba443d0be911fb5db504cb14cd
Signed-off-by: Roman Birg roman@cyngn.com
